### PR TITLE
coop package missing on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 inst/doc
 FastPCA.Rproj
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
+Imports: 
+    coop


### PR DESCRIPTION
Added via devtools::use_package("coop")